### PR TITLE
Add Discord Command Handler

### DIFF
--- a/commands/command_registry.js
+++ b/commands/command_registry.js
@@ -1,0 +1,8 @@
+const ping = require('./ping');
+const commands = [
+    ping
+];
+
+module.exports = {
+    getAll: () => commands
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -254,6 +254,11 @@
         "verror": "1.10.0"
       }
     },
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+    },
     "mime-db": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A discord bot that delivers important cryptocurrency movement news",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1", 
+    "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node index.js"
   },
   "author": "Eduardo Olivares",
@@ -12,6 +12,7 @@
   "dependencies": {
     "discord.js": "^12.5.1",
     "dotenv": "^8.2.0",
+    "lodash": "^4.17.20",
     "request": "^2.88.2"
   }
 }

--- a/services/discord_command_handler.js
+++ b/services/discord_command_handler.js
@@ -1,0 +1,51 @@
+const _ = require('lodash');
+
+// TODO: at some point, it probably makes sense to move this to a seperate command and have that print out useable commands.
+// In the meantime, if a command cannot be found, use the Default Command.
+const DEFAULT_COMMAND = {
+    execute: (message, args) => {}
+}
+
+class DiscordCommandHandler {
+    constructor(discordClient, prefix='$') {
+        this._discordClient = discordClient;
+        this._commandLookup = {}
+        this.prefix = prefix;
+    }
+
+    registerCommands(commands) {
+        for (const command of commands) {
+            const name = command.name;
+            if (name in this._commandLookup) {
+                // command name collision
+                console.log(`Command name collision. ${name} already exists, overwriting!`)
+            }
+            this._commandLookup[name] = command
+        }
+    }
+
+    getCommand(command) {
+        const fn = _.get(this._commandLookup, command, undefined);
+        if (!fn) {
+            console.log(`Command: ${command} not found. Using default.`)
+            return DEFAULT_COMMAND
+        }
+        return fn
+    }
+
+    listen() {
+        this._discordClient.on('message',  this._processCommand.bind(this))
+    }
+
+    _processCommand(message) {
+        if (!message.content.startsWith(this.prefix) || message.author.bot) return;
+        const args = message.content.slice(this.prefix.length).split(/ +/);
+        const command = args.shift().toLowerCase();
+        const commandObj = this.getCommand(command);
+        commandObj.execute(message, args);
+    }
+}
+
+module.exports = {
+    DiscordCommandHandler: DiscordCommandHandler
+}


### PR DESCRIPTION
Move command handling logic into separate units. Thinking it might help with composability later on reduces logic inside main `index.js`

Tested locally:
1. start server
2. send `$ping coingecko` to discord channel
3. Bot posts message