### PR TITLE
Add configurable narwhal prefix

### DIFF
--- a/commands/command_registry.js
+++ b/commands/command_registry.js
@@ -1,5 +1,8 @@
+const narwhalPrefix = require('./narwhal_prefix');
 const ping = require('./ping');
+
 const commands = [
+    narwhalPrefix,
     ping
 ];
 

--- a/commands/narwhal_prefix.js
+++ b/commands/narwhal_prefix.js
@@ -1,0 +1,27 @@
+const localCache = require('../services/local_cache');
+const dotEnv = require('dotenv').config();
+const _ = require('lodash');
+
+const ALLOWED_ROLES = process.env.PREFIX_CHANGE_ROLES.split(',');
+const hasPermissions = (message) => {
+    return message.member.roles.cache.some((role) => ALLOWED_ROLES.includes(role.name));
+}
+
+module.exports = {
+    name: 'narwhalPrefix',
+    description: "Allows a user to change the prefix for Narwhal. Default is `$`",
+    execute(message, args){
+        if (args.length != 1) {
+            message.channel.send('EHHHHH...Use it like this: <current prefix>prefix <new prefix>');
+            return;
+        }
+        if (!hasPermissions(message)){
+            message.channel.send('You do not have permissions to change this.');
+            return;
+        }
+        const cache = localCache.getInstance();
+        const newPrefix = args[0]
+        cache.put('PREFIX', 'value', newPrefix);
+        message.channel.send(`You may now speak to me using ${newPrefix}`);
+    }
+}

--- a/services/discord_command_handler.js
+++ b/services/discord_command_handler.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const localCache = require('./local_cache');
 
 // TODO: at some point, it probably makes sense to move this to a seperate command and have that print out useable commands.
 // In the meantime, if a command cannot be found, use the Default Command.
@@ -10,7 +11,7 @@ class DiscordCommandHandler {
     constructor(discordClient, prefix='$') {
         this._discordClient = discordClient;
         this._commandLookup = {}
-        this.prefix = prefix;
+        this.cache = localCache.getInstance();
     }
 
     registerCommands(commands) {
@@ -38,11 +39,16 @@ class DiscordCommandHandler {
     }
 
     _processCommand(message) {
-        if (!message.content.startsWith(this.prefix) || message.author.bot) return;
-        const args = message.content.slice(this.prefix.length).split(/ +/);
-        const command = args.shift().toLowerCase();
+        const registeredPrefix = this._getPrefix(message);
+        if (!message.content.startsWith(registeredPrefix) || message.author.bot) return;
+        const args = message.content.slice(registeredPrefix.length).split(/ +/);
+        const command = args.shift();
         const commandObj = this.getCommand(command);
         commandObj.execute(message, args);
+    }
+
+    _getPrefix(message) {
+        return this.cache.get('PREFIX', 'value') || '$';
     }
 }
 

--- a/services/local_cache.js
+++ b/services/local_cache.js
@@ -1,0 +1,55 @@
+// Use this as a local cache storage
+// 
+// The way you can think about this is:
+// Each thing will have a top level name (i.e. PREFIX), this will be called a `collection`.
+// Every collection will be comprised of an object that is up to the user to use as they need.
+// TODO: This probably becomes an issue later on when namespace collisions start happening, at which point this probably cant be used anyway
+// but until we need to scale to a database, we can use this as a way to hold state.
+//
+// LocalCache is a singleton object which should only be instantiated with the getInstance method
+//
+// Usage:
+// const localCache = require(<this file path>);
+// const cache = localCache.getInstance()
+// cache.put('PREFIX', value, newPrefix)
+// cache.get('PREFIX', value)
+
+const _ = require('lodash');
+
+const getInstance = () => {
+    return new LocalCache();
+}
+
+class LocalCache {
+    static _instance = null;
+    constructor() {
+        if(LocalCache._instance) {
+            return LocalCache._instance;
+        }
+        LocalCache._instance = this;
+        this.storage = {
+            'PREFIX': {
+                'value': '$'
+            },
+            'BINDS': {} // @Eduardo, if you want to use this for binds, maybe you can put defaults in here.
+        }
+    }
+
+    put(collectionName, key, value) {
+        const collection = _.get(this.storage, collectionName, undefined);
+        if (!collection) {
+            throw Error(`${collectionName} is not a registered collection for LocalStorage`)
+        }
+        _.set(this.storage, `${collectionName}.${key}`, value)
+    }
+
+    get(collectionName, key) {
+        const collection = _.get(this.storage, collectionName);
+        if (!collection) return undefined;
+        return _.get(collection, key)
+    }
+}
+
+module.exports = {
+    getInstance: getInstance
+}


### PR DESCRIPTION
The permissions for this is based in the `.env` file. It looks for the key: `PREFIX_CHANGE_ROLES`.
I.e.
```
PREFIX_CHANGE_ROLES=Admin1
```

The values for this can be presented as a comma separated string if multiple roles are needed.
i.e.
```
PREFIX_CHANGE_ROLES=Admin1,Admin2,Admin3
```

Tested this locally:
1. Give myself only the 'Admin' role.
2. In .env, set PREFIX_CHANGE_ROLES=Admin
3. sending `$narwhalPrefix ~` results in bot responding: `You may now speak to me using ~`
4. sending `$narwhalPrefix ~` results in no message.
5. sending `~narwhalPrefix $` results in bot responding: `You may now speak to me using $`
6. restarting the server with .env as PREFIX_CHANGE_ROLES=FakeRole
7. sending `$narwhalPrefix ~` results in bot responding: `You do not have permissions to change this.`